### PR TITLE
Fix IP validation logic and prevent invalid octet values

### DIFF
--- a/Session-11-adv-bash-2/regex3.sh
+++ b/Session-11-adv-bash-2/regex3.sh
@@ -1,20 +1,18 @@
 #!/bin/bash
-read -rp "Enter Your IP: " ip
-if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]
-then
-  echo "Valid IP"
-else
-  echo "Invalid IP"
+
+read -rp "Enter your IP address: " ip
+# Step 1: Validate IP format
+if [[ ! $ip =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    echo "Invalid IP format"
+    exit 1
 fi
-
-#!/bin/bash
-
-read -p "Enter an IP address: " ip
-ip="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
-
-if [[ $ip =~ $ip ]]; then
-        echo "connect"
-    else
-        echo "Disconnect"
+# Step 2: Validate each octet range (0–255)
+IFS='.' read -r o1 o2 o3 o4 <<< "$ip"
+for octet in $o1 $o2 $o3 $o4; do
+    if (( octet < 0 || octet > 255 )); then
+        echo "Invalid IP address (octet out of range)"
+        exit 1
     fi
+done
 
+echo "Valid IP address"


### PR DESCRIPTION
This PR improves IP address validation logic as discussed in the Issue.
Changes:
- Prevents invalid IPs like 999.999.999.999
- Fixes variable overwrite issue
- Adds numeric validation for each octet (0–255)